### PR TITLE
fix property warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,6 @@
 LineLength:
   Max: 180
 
-##  don't need class documentation header for custom resources. 
+##  don't need class documentation header for custom resources.
 Documentation:
   Enabled: false

--- a/libraries/ibm_package.rb
+++ b/libraries/ibm_package.rb
@@ -24,21 +24,21 @@ module InstallMgrCookbook
     include InstallMgrHelpers
 
     resource_name :ibm_package
-    property :package, String, required: true, default: nil # eg 'com.ibm.websphere.ND.v85_8.5.5000.20130514_1044'
-    property :install_dir, String, required: true, default: nil
+    property :package, String, required: true # eg 'com.ibm.websphere.ND.v85_8.5.5000.20130514_1044'
+    property :install_dir, String, required: true
     property :imcl_dir, String, default: '/opt/IBM/InstallationManager/eclipse/tools'
-    property :repositories, [String, Array], default: nil
+    property :repositories, [String, Array, nil], default: nil
     property :passport_advantage, [TrueClass, FalseClass], default: false
     property :service_user, String, default: 'ibm'
     property :service_group, String, default: 'ibm'
-    property :properties, [Hash], default: nil
-    property :preferences, [Hash], default: nil
+    property :properties, [Hash, nil], default: nil
+    property :preferences, [Hash, nil], default: nil
     property :install_fixes, String, default: 'none', regex: /^(none|recommended|all)$/
     property :additional_options, String, default: ''
     property :access_rights, String, default: 'nonAdmin', regex: /^(nonAdmin|admin|group)$/
     property :log_dir, String, default: '/var/IBM/InstallationManager/logs'
-    property :secure_storage_file, String, default: nil
-    property :master_pw_file, String, default: nil
+    property :secure_storage_file, [String, nil], default: nil
+    property :master_pw_file, [String, nil], default: nil
     property :sensitive_exec, [TrueClass, FalseClass], default: true # only turn this off in exceptional debugging circumstances.
 
     # TODO: Include the below properties at some stage

--- a/libraries/ibm_package_response.rb
+++ b/libraries/ibm_package_response.rb
@@ -25,7 +25,7 @@ module InstallMgrCookbook
 
     resource_name :ibm_package_response
     property :package, String, name_property: true
-    property :response_file, String, required: true, default: nil
+    property :response_file, String, required: true
     property :imcl_dir, String, default: '/opt/IBM/InstallationManager/eclipse/tools'
     property :log_dir, String, default: '/var/IBM/InstallationManager/logs'
     property :pkg_group, String, default: 'ibm'

--- a/libraries/ibm_response_file.rb
+++ b/libraries/ibm_response_file.rb
@@ -25,9 +25,9 @@ module InstallMgrCookbook
     property :response_file, String, name_property: true
     property :group, String, default: 'ibm-im'
     property :owner, String, default: 'ibm-im'
-    property :template_source, String, default: nil
-    property :cookbook, String, default: nil
-    property :variables, [Hash], default: nil
+    property :template_source, [String, nil], default: nil
+    property :cookbook, [String, nil], default: nil
+    property :variables, [Hash, nil], default: nil
 
     action :create do
       config_dir = ::File.dirname(response_file)

--- a/libraries/ibm_secure_storage_file.rb
+++ b/libraries/ibm_secure_storage_file.rb
@@ -22,13 +22,13 @@ module InstallMgrCookbook
   class IbmSecureStorageFile < Chef::Resource
     resource_name :ibm_secure_storage_file
     property :secure_file, String, name_property: true
-    property :master_pw_file, String, default: nil
-    property :master_pw, String, default: nil
+    property :master_pw_file, [String, nil], default: nil
+    property :master_pw, [String, nil], default: nil
     property :url, String, default: 'http://www.ibm.com/software/repositorymanager/entitled/repository.xml'
     property :imutilsc_dir, String, default: '/opt/IBM/InstallationManager/eclipse/tools'
     property :passport_advantage, [TrueClass, FalseClass], default: false
-    property :username, String, default: nil
-    property :password, String, default: nil
+    property :username, [String, nil], default: nil
+    property :password, [String, nil], default: nil
     property :sensitive_exec, [TrueClass, FalseClass], default: true
 
     action :create do

--- a/libraries/install_mgr.rb
+++ b/libraries/install_mgr.rb
@@ -25,8 +25,8 @@ module InstallMgrCookbook
     include InstallMgrHelpers
 
     resource_name :install_mgr
-    property :install_package, String, required: true, default: nil # can be url or local path to a compressed file
-    property :install_package_sha256, String, default: nil
+    property :install_package, String, required: true # can be url or local path to a compressed file
+    property :install_package_sha256, [String, nil], default: nil
     property :download_temp_dir, String, default: Chef::Config['file_cache_path']
     property :extract_dir, String, default: lazy { "#{download_temp_dir}/ibm-installmgr" }
     property :install_dir, String, default: lazy { "#{ibm_root_dir}/InstallationManager/eclipse" }


### PR DESCRIPTION
This fixes the new warnings from chef-client 12.7+ on property definitions for custom resources. 